### PR TITLE
fix markers list generation for markers selection

### DIFF
--- a/application/assets/js/module.js
+++ b/application/assets/js/module.js
@@ -184,11 +184,21 @@ const module = (() => {
   ///////////////////
   //select marker
   ////////////////////
+  // Flag to keep track of the need 
+  // of generating the new marker lis
+  var f_upd_markers_list = true;
+  let set_f_upd_markers = function () {
+      f_upd_markers_list = true;
+  };
+
   contained = []; //makers in map boundingbox
   let l = [];
   let index = -1;
   let select_marker = function () {
-    if (contained == "") {
+    if (f_upd_markers_list) {
+      // Reset contained list
+      contained = []
+
       //merge markers in viewport
       if (overpass_group != "") {
         overpass_group.eachLayer(function (l) {
@@ -202,6 +212,9 @@ const module = (() => {
         if (l instanceof L.Marker && map.getBounds().contains(l.getLatLng()))
           contained.push(l);
       });
+
+      // Clear flag
+      f_upd_markers_list = false;
     }
 
     l = contained;
@@ -569,6 +582,7 @@ const module = (() => {
   };
 
   return {
+    set_f_upd_markers,
     select_marker,
     calc_distance,
     compass,

--- a/application/index.js
+++ b/application/index.js
@@ -1036,6 +1036,7 @@ document.addEventListener("DOMContentLoaded", function () {
         document.querySelector("div#markers-option").style.display = "none";
         status.windowOpen = "map";
         bottom_bar("", "", "");
+        module.set_f_upd_markers();
       }
 
       if (item_value == "save_marker") {
@@ -1977,10 +1978,12 @@ document.addEventListener("DOMContentLoaded", function () {
         break;
 
       case "9":
-        if (status.windowOpen == "map")
+        if (status.windowOpen == "map") {
           L.marker([mainmarker.current_lat, mainmarker.current_lng]).addTo(
             markers_group
           );
+          module.set_f_upd_markers();
+        }
         break;
 
       case "0":


### PR DESCRIPTION
I don't know if this was a desired feature, but I encountered a problem when selecting markers: after having performed some jumps between existing markers (i.e., pressing "*"), the markers that were added afterwards (i.e., by pressing "9") were not taken into account by future jumps. 

I identified that the lists of markers was generated only once when the first marker jump/selection was performed. 

To fix the identified issue, I added the flag "f_upd_markers_list" in "module.js" that keep track of any marker addition / deletion. More practically, the accessor function "set_f_upd_markers()" is called from "index.js" to raise the flag when either a marker is added or deleted. The list of markers "contained" is rebuilt if this flag is set at each call of the function "select_markers()". The flag is reset at each list re-building to avoid unnecessary operation when no modification of marker has been made. 

Hope it helps. 