### PR TITLE
Fix routing file and end tracking

### DIFF
--- a/application/assets/js/module.js
+++ b/application/assets/js/module.js
@@ -562,7 +562,7 @@ const module = (() => {
       document.querySelector("div#tracking-evo-up span").innerText = "";
       document.querySelector("div#tracking-evo-down span").innerText = "";
       document.querySelector("div#tracking-moving-time span").innerText = "";
-      document.querySelector("tracking-speed-average-time").innerText = "";
+      document.querySelector("div#tracking-speed-average-time").innerText = "";
 
       clearInterval(tracking_interval);
       setTimeout(function () {

--- a/application/index.js
+++ b/application/index.js
@@ -135,7 +135,6 @@ document.addEventListener("DOMContentLoaded", function () {
           //fly to start
           p = feature.geometry.coordinates[0];
 
-            // FIXME: here the reverse seems to induce an inversion of the coordinates for the write
           reverse_2D_array = feature.geometry.coordinates.map((row) =>
             row.reverse()
           );
@@ -164,6 +163,10 @@ document.addEventListener("DOMContentLoaded", function () {
             mm[0] + "," + mm[1];
 
           i = feature.properties.segments[0].steps;
+            // Reverse back
+            reverse_2D_array = feature.geometry.coordinates.map((row) =>
+                row.reverse()
+            );
           //if the file is a routing file
           if (file_loaded) {
             try {
@@ -179,8 +182,9 @@ document.addEventListener("DOMContentLoaded", function () {
                 feature.geometry.coordinates.length - 1
               ];
 
-            routing.start = [m[0], m[1]];
-            routing.end = [mm[0], mm[1]];
+            // Reverse from file
+            routing.start = [m[1], m[0]];
+            routing.end = [mm[1], mm[0]];
 
             //add marker
             let s = L.marker(routing.start).addTo(markers_group);

--- a/application/index.js
+++ b/application/index.js
@@ -135,6 +135,7 @@ document.addEventListener("DOMContentLoaded", function () {
           //fly to start
           p = feature.geometry.coordinates[0];
 
+            // FIXME: here the reverse seems to induce an inversion of the coordinates for the write
           reverse_2D_array = feature.geometry.coordinates.map((row) =>
             row.reverse()
           );

--- a/application/index.js
+++ b/application/index.js
@@ -163,10 +163,10 @@ document.addEventListener("DOMContentLoaded", function () {
             mm[0] + "," + mm[1];
 
           i = feature.properties.segments[0].steps;
-            // Reverse back
-            reverse_2D_array = feature.geometry.coordinates.map((row) =>
-                row.reverse()
-            );
+          // Reverse back
+          reverse_2D_array = feature.geometry.coordinates.map((row) =>
+              row.reverse()
+          );
           //if the file is a routing file
           if (file_loaded) {
             try {


### PR DESCRIPTION
Hi, 

I spotted some behaviours that I believe are bugs on the master branch code and propose some fixes. Namely:

- The loading/writing of routing GeoJSON file was inversing the order of the latitude/longitude data for sequential load/write of the same file (which was afterwards showing wrong paths on the map due to the reversed coordinates).The error was coming from the fact that the received/loaded data was reversed before usage but not reversed back to its original form. I added the reversing step in the file `index.js`. I also fixed accordingly the starting/ending routing trackers coordinates. 
- When ending a tracking, the app was continuing to track the user (i.e., marker kept in tracking mode and all the tracking metrics were still updated once a tracking was stopped). I tracked down the bug to the function 'measure_distance' in 'module.js' that was failing to execute properly the line 
```
document.querySelector("tracking-speed-average-time").innerText = "";
```
which was inducing that the ending of the tracking procedure was not applied afterwards. I modified the line as follows
```
document.querySelector("div#tracking-speed-average-time").innerText = "";
```
and the app seems to work properly now. 

Hope it helps.