### PR TITLE
Add origin to manifest

### DIFF
--- a/application/manifest.webapp
+++ b/application/manifest.webapp
@@ -13,6 +13,7 @@
     "112": "/assets/icons/icon-112-112.png"
   },
 
+  "origin": "app://omap.strukturart.com",
   "developer": {
     "name": "strukturart",
     "url": "https://github.com/strukturart/o.map"

--- a/application/manifest.webmanifest
+++ b/application/manifest.webmanifest
@@ -8,6 +8,7 @@
   "display": "standalone",
   "userAgentInfo": "o.map written by strukturart@gmail.com",
 
+  "origin": "app://omap.strukturart.com",
   "icons": [
     {
       "src": "/assets/icons/icon-56-56.png",


### PR DESCRIPTION
This is needed, so other apps can find the app and launch it. 
I needed this to add the app to sidebar (it's in KaiOS 3.0> I think)